### PR TITLE
eon 2.15.0 (win in-tree Fortran #15; drop v2.14.0 potinit patch)

### DIFF
--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -1,21 +1,24 @@
 @echo on
 
+:: conda-forge/eon-feedstock#15: enable IN-TREE Fortran on win-64 (not skip it).
+:: Strategy (see https://rgoswami.me/posts/windows-compat-sci-cpp/):
+::   - C++/Python/torch/metatomic: MSVC (conda-forge default win-64 compilers)
+::   - In-tree Fortran pots (EAM/GAGAFE/CuH2 etc.): m2w64 gfortran via compiler('fortran')
+::   - MinGW-built xtb: generate MSVC import lib from DLL exports (ABI boundary)
+::   - Stack: meson sets /STACK:16777216 for MSVC link (Windows 1 MB default overflows
+::     legacy Fortran stack arrays; Linux default is 8 MB)
+
 :: cbindgen has no conda-forge win-64 build; grab it via cargo into the host
 :: prefix so readcon-core's meson subproject can generate its C header.
-:: Matches the ensure_cbindgen fallback in the upstream pixi.toml.
 cargo install --root "%LIBRARY_PREFIX%" cbindgen
 if errorlevel 1 exit 1
 
 :: Remove wrap files to prevent meson from building subprojects from source
-:: All dependencies are provided by conda packages
 del /q subprojects\xtb.wrap 2>nul
 del /q subprojects\vesin.wrap 2>nul
 del /q subprojects\rgpot.wrap 2>nul
 
-
 :: Generate MSVC-compatible import library from MinGW-built xtb DLL
-:: The xtb conda package is built with m2w64 and only ships libxtb.dll.a
-:: Find the DLL: try versioned libxtb-*.dll first, then unversioned libxtb.dll
 set "XTB_DLL_NAME="
 for %%F in ("%LIBRARY_BIN%\libxtb-*.dll") do (
     if not defined XTB_DLL_NAME set "XTB_DLL_NAME=%%~nxF"
@@ -37,36 +40,27 @@ for /f "skip=19 tokens=4" %%A in (xtb_exports.txt) do (
 lib /DEF:xtb.def /OUT:"%LIBRARY_LIB%\xtb.lib" /MACHINE:X64
 if errorlevel 1 exit 1
 
-:: Ensure host python can find its own site-packages (numpy)
 set "PYTHONPATH=%SP_DIR%;%PYTHONPATH%"
 
-:: inih is pulled in as a meson wrap (eon v2.14 dropped the vendored
-:: client/INIFile.* in favor of inih's INIReader); there is no conda-forge
-:: binary for any subdir so meson must be allowed to fall back to the wrap.
-:: Mirror non-Windows behavior (no --wrap-mode override).
-:: Also patch readcon-core's upstream meson.build in case the Windows
-:: rust_compiler activation sets CARGO_BUILD_TARGET (target-dir layout
-:: gains a <triple>/ component then).
 meson subprojects download readcon-core
 if errorlevel 1 exit 1
 python -c "import pathlib; p=pathlib.Path('subprojects/readcon-core/meson.build'); t=p.read_text(); old='\"/cargo-target/release/\"'; new='\"/cargo-target/\" + (__import__(\"os\").environ.get(\"CARGO_BUILD_TARGET\", \"\") + \"/\" if __import__(\"os\").environ.get(\"CARGO_BUILD_TARGET\") else \"\") + \"release/\"'; p.write_text(t.replace(old, new))"
 if errorlevel 1 exit 1
 
-:: Bundle every transitive Rust crate license that readcon-core pulls into
-:: THIRDPARTY.yml. about.license_file in recipe.yaml references this file.
 pushd subprojects\readcon-core
 cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
 if errorlevel 1 (popd & exit 1)
 popd
 
+:: In-tree Fortran ON including CuH2 (issue #15). Static default-library for MSVC/MinGW pot objects.
 meson setup -Dpython.install_env=prefix ^
     --prefix="%PREFIX%" ^
     --default-library=static ^
     -Dwith_metatomic=True ^
     -Dwith_xtb=True ^
     -Dwith_serve=True ^
-    -Dwith_fortran=false ^
-    -Dwith_cuh2=false ^
+    -Dwith_fortran=true ^
+    -Dwith_cuh2=true ^
     -Dpip_metatomic=False ^
     -Dtorch_path="%LIBRARY_PREFIX%" ^
     --pkg-config-path="%LIBRARY_LIB%\pkgconfig" ^

--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -10,11 +10,27 @@
 ::   - MinGW-built xtb: generate MSVC import lib from DLL exports (ABI boundary)
 ::   - Stack: meson sets /STACK:16777216 for MSVC link (Windows 1 MB default overflows
 ::     legacy Fortran stack arrays; Linux default is 8 MB)
+:: Cargo: HTTP/1.1 + retries (crates.io HTTP2 framing fails on some runners, incl. aarch64).
+
+set "CARGO_HTTP_MULTIPLEXING=false"
+set "CARGO_NET_RETRY=10"
+set "CARGO_HTTP_TIMEOUT=300"
 
 :: cbindgen has no conda-forge win-64 build; grab it via cargo into the host
 :: prefix so readcon-core's meson subproject can generate its C header.
+set "CARGO_ATTEMPT=0"
+:cargo_install_cbindgen
+set /a CARGO_ATTEMPT+=1
 cargo install --root "%LIBRARY_PREFIX%" cbindgen
-if errorlevel 1 exit 1
+if errorlevel 1 (
+    if %CARGO_ATTEMPT% GEQ 5 (
+        echo ERROR: cargo install cbindgen failed after %CARGO_ATTEMPT% attempts
+        exit 1
+    )
+    echo WARN: cargo install cbindgen attempt %CARGO_ATTEMPT% failed; retrying...
+    timeout /t 10 /nobreak >nul
+    goto cargo_install_cbindgen
+)
 
 :: Remove wrap files to prevent meson from building subprojects from source
 del /q subprojects\xtb.wrap 2>nul
@@ -66,8 +82,33 @@ python -c "import pathlib; p=pathlib.Path('subprojects/readcon-core/meson.build'
 if errorlevel 1 exit 1
 
 pushd subprojects\readcon-core
+set "CARGO_ATTEMPT=0"
+:cargo_fetch_readcon
+set /a CARGO_ATTEMPT+=1
+cargo fetch --locked
+if errorlevel 1 cargo fetch
+if errorlevel 1 (
+    if %CARGO_ATTEMPT% GEQ 5 (
+        echo ERROR: cargo fetch readcon-core failed after %CARGO_ATTEMPT% attempts
+        popd & exit 1
+    )
+    echo WARN: cargo fetch attempt %CARGO_ATTEMPT% failed; retrying...
+    timeout /t 10 /nobreak >nul
+    goto cargo_fetch_readcon
+)
+set "CARGO_ATTEMPT=0"
+:cargo_bundle_licenses
+set /a CARGO_ATTEMPT+=1
 cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
-if errorlevel 1 (popd & exit 1)
+if errorlevel 1 (
+    if %CARGO_ATTEMPT% GEQ 5 (
+        echo ERROR: cargo-bundle-licenses failed after %CARGO_ATTEMPT% attempts
+        popd & exit 1
+    )
+    echo WARN: cargo-bundle-licenses attempt %CARGO_ATTEMPT% failed; retrying...
+    timeout /t 10 /nobreak >nul
+    goto cargo_bundle_licenses
+)
 popd
 
 :: In-tree Fortran ON including CuH2 (issue #15). Static default-library; MSVC AR above.

--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -76,6 +76,25 @@ if errorlevel 1 (
     exit 1
 )
 
+:: flang_rt import libs live under clang resource dir; MSVC link needs LIBPATH
+:: (LNK1104: cannot open file 'flang_rt.runtime.dynamic.lib' otherwise).
+set "FLANG_RT_DIR="
+for /f "delims=" %%R in ('flang -print-resource-dir 2^>nul') do set "FLANG_RT_DIR=%%R\lib\x86_64-pc-windows-msvc"
+if defined FLANG_RT_DIR (
+    if exist "%FLANG_RT_DIR%\flang_rt.runtime.dynamic.lib" (
+        set "LIB=%FLANG_RT_DIR%;%LIB%"
+        echo Using flang_rt LIBPATH: %FLANG_RT_DIR%
+    )
+)
+if not defined FLANG_RT_DIR (
+    for /d %%D in ("%LIBRARY_PREFIX%\lib\clang\*") do (
+        if exist "%%D\lib\x86_64-pc-windows-msvc\flang_rt.runtime.dynamic.lib" (
+            set "LIB=%%D\lib\x86_64-pc-windows-msvc;%LIB%"
+            echo Using flang_rt LIBPATH: %%D\lib\x86_64-pc-windows-msvc
+        )
+    )
+)
+
 meson subprojects download readcon-core
 if errorlevel 1 exit 1
 python -c "import pathlib; p=pathlib.Path('subprojects/readcon-core/meson.build'); t=p.read_text(); old='\"/cargo-target/release/\"'; new='\"/cargo-target/\" + (__import__(\"os\").environ.get(\"CARGO_BUILD_TARGET\", \"\") + \"/\" if __import__(\"os\").environ.get(\"CARGO_BUILD_TARGET\") else \"\") + \"release/\"'; p.write_text(t.replace(old, new))"

--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -3,7 +3,10 @@
 :: conda-forge/eon-feedstock#15: enable IN-TREE Fortran on win-64 (not skip it).
 :: Strategy (see https://rgoswami.me/posts/windows-compat-sci-cpp/):
 ::   - C++/Python/torch/metatomic: MSVC (conda-forge default win-64 compilers)
-::   - In-tree Fortran pots (EAM/GAGAFE/CuH2 etc.): m2w64 gfortran via compiler('fortran')
+::   - In-tree Fortran pots (EAM/GAGAFE/CuH2 etc.): compiler('fortran') — currently
+::     conda-forge win ships llvm-flang; C++/link stay MSVC (cl.exe / link.exe)
+::   - Archiver: MUST be MSVC lib.exe. Enabling fortran pulls flang which otherwise
+::     selects llvm-ar; MSVC link then fails with LNK1107 on .a files (libptlrpc etc.)
 ::   - MinGW-built xtb: generate MSVC import lib from DLL exports (ABI boundary)
 ::   - Stack: meson sets /STACK:16777216 for MSVC link (Windows 1 MB default overflows
 ::     legacy Fortran stack arrays; Linux default is 8 MB)
@@ -42,6 +45,21 @@ if errorlevel 1 exit 1
 
 set "PYTHONPATH=%SP_DIR%;%PYTHONPATH%"
 
+:: Keep C/C++/link on MSVC even though compiler('fortran') injects flang/llvm-ar.
+:: Without this, meson archives with llvm-ar and final MSVC link fails (LNK1107).
+set "CC=cl.exe"
+set "CXX=cl.exe"
+set "AR=lib"
+set "ARFLAGS="
+set "NM=dumpbin"
+set "RANLIB=:"
+:: Prefer MSVC link over lld-link from the flang/clang activation.
+where link >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: MSVC link.exe not on PATH; vsenv/activation missing
+    exit 1
+)
+
 meson subprojects download readcon-core
 if errorlevel 1 exit 1
 python -c "import pathlib; p=pathlib.Path('subprojects/readcon-core/meson.build'); t=p.read_text(); old='\"/cargo-target/release/\"'; new='\"/cargo-target/\" + (__import__(\"os\").environ.get(\"CARGO_BUILD_TARGET\", \"\") + \"/\" if __import__(\"os\").environ.get(\"CARGO_BUILD_TARGET\") else \"\") + \"release/\"'; p.write_text(t.replace(old, new))"
@@ -52,7 +70,7 @@ cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
 if errorlevel 1 (popd & exit 1)
 popd
 
-:: In-tree Fortran ON including CuH2 (issue #15). Static default-library for MSVC/MinGW pot objects.
+:: In-tree Fortran ON including CuH2 (issue #15). Static default-library; MSVC AR above.
 meson setup -Dpython.install_env=prefix ^
     --prefix="%PREFIX%" ^
     --default-library=static ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,32 @@
 
 set -o xtrace -o nounset -o pipefail -o errexit
 
+# crates.io / curl on some runners (esp. linux_aarch64 GHA) fails with
+# "Error in the HTTP2 framing layer" during cargo install / cargo-bundle-licenses.
+# HTTP/1.1 + retries makes aarch64 (and win) builds reliable without vendoring.
+export CARGO_HTTP_MULTIPLEXING="${CARGO_HTTP_MULTIPLEXING:-false}"
+export CARGO_NET_RETRY="${CARGO_NET_RETRY:-10}"
+export CARGO_HTTP_TIMEOUT="${CARGO_HTTP_TIMEOUT:-300}"
+
+# Retry a command up to N times with backoff (network to crates.io is flaky on aarch64).
+cargo_retry() {
+    local max="${1:-5}"
+    shift
+    local attempt=1
+    local delay=5
+    until "$@"; do
+        if [[ "${attempt}" -ge "${max}" ]]; then
+            echo "ERROR: command failed after ${max} attempts: $*" >&2
+            return 1
+        fi
+        echo "WARN: attempt ${attempt}/${max} failed; retrying in ${delay}s: $*" >&2
+        sleep "${delay}"
+        attempt=$((attempt + 1))
+        delay=$((delay * 2))
+        if [[ "${delay}" -gt 60 ]]; then delay=60; fi
+    done
+}
+
 # cbindgen is not packaged on conda-forge for any subdir; bootstrap it via
 # cargo into the build prefix so readcon-core's meson subproject can
 # generate its C header. Matches the ensure_cbindgen fallback in the
@@ -9,7 +35,10 @@ set -o xtrace -o nounset -o pipefail -o errexit
 # honors CARGO_BUILD_TARGET and would build an arm64 binary that cannot
 # run on the x86_64 build machine -- drop the target locally so cargo
 # emits a build-native executable.
-(unset CARGO_BUILD_TARGET; cargo install --root "${BUILD_PREFIX}" cbindgen)
+(
+    unset CARGO_BUILD_TARGET
+    cargo_retry 5 cargo install --root "${BUILD_PREFIX}" cbindgen
+)
 export PATH="${BUILD_PREFIX}/bin:${PATH}"
 
 # Remove wrap files to prevent meson from building subprojects from source
@@ -45,9 +74,13 @@ sed -i.bak \
     subprojects/readcon-core/meson.build
 rm -f subprojects/readcon-core/meson.build.bak
 
-# Bundle every transitive Rust crate license that readcon-core pulls into
-# THIRDPARTY.yml. about.license_file in recipe.yaml references this file.
-(cd subprojects/readcon-core && cargo-bundle-licenses --format yaml --output THIRDPARTY.yml)
+# Warm the registry/cache then bundle licenses (policy: THIRDPARTY.yml for Rust deps).
+# cargo-bundle-licenses runs `cargo metadata` which hits crates.io; prime with fetch.
+(
+    cd subprojects/readcon-core
+    cargo_retry 5 cargo fetch --locked 2>/dev/null || cargo_retry 5 cargo fetch
+    cargo_retry 5 cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+)
 
 # On cross builds (osx_arm64 from osx_64 hosts) conda-forge passes a
 # --cross-file via MESON_ARGS but does not populate [binaries] rust in it.

--- a/recipe/fix_win_cuh2_potinit.patch
+++ b/recipe/fix_win_cuh2_potinit.patch
@@ -1,0 +1,31 @@
+# v2.14.0 only: aluminum+cuh2 are both static `library()` targets linked into
+# eonclient, so MSVC link fails with LNK2005 on potinit_ (gfortran archives
+# tolerate the duplicate).  Rename the CuH2-local initializer; aluminum keeps
+# potinit_ for its Fortran pot.  v2.15.0+ loads aluminum via dlopen/shared
+# lib and does not need this patch.
+--- a/client/potentials/CuH2/eamroutines.f90
++++ b/client/potentials/CuH2/eamroutines.f90
+@@ -34,7 +34,7 @@
+         do i=1,natoms
+            iatclass(i)=i
+         end do
+-        CALL potinit()
++        CALL cuh2_potinit()
+ 
+ 
+         do i=1,ndim
+@@ -480,7 +480,7 @@
+       return
+     end subroutine EAMRhoH
+ 
+-      SUBROUTINE potinit()
++      SUBROUTINE cuh2_potinit()
+ 
+         IMPLICIT NONE
+         REAL*8 phitemp,dphidr_r,rhotemp,drhodr_r,potpar(18,3)
+@@ -615,4 +615,4 @@
+         rhocutH = rhotemp
+         drhoHdr_r = drhodr_r
+ 
+-      END SUBROUTINE potinit
++      END SUBROUTINE cuh2_potinit

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -7,9 +7,8 @@ package:
 
 source:
   - url: https://github.com/TheochemUI/eOn/releases/download/v${{ version }}/eon-v${{ version }}.tar.xz
-    # Recompute after tag push: curl -sL "$url" | sha256sum
-    # Placeholder from local git archive HEAD (release/v2.15.0-prep); replace with GH asset hash.
-    sha256: b873ece9340d51e926b0e2215ef9fd4438a4ecba3081159c7ed69e18f84ae345
+    # Published asset from TheochemUI/eOn v2.15.0 release.yml (git archive tarball).
+    sha256: d4695f81ffd7a1c729f48b5c42737d381c686c79ca63ca95769f31415a3798b7
     # v2.15.0+ ships runtime-loadable Fortran pots (#342); fix_win_cuh2_potinit was v2.14.0-only.
   - url: https://github.com/OmniPotentRPC/rgpot/archive/refs/tags/v1.0.3.tar.gz
     sha256: b46d9d6ecb0d47c621d7ec6051c19025d3254b366d4c98232168f74b75c0f7da

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -35,7 +35,9 @@ requirements:
     # `cargo install`, matching the ensure_cbindgen fallback in pixi.toml.
     - ${{ compiler('rust') }}
     # Required by conda-forge policy for Rust packages: bundle the licenses
-    # of every transitive Rust dependency into THIRDPARTY.yml.
+    # of every transitive Rust dependency into THIRDPARTY.yml. build.sh/bat
+    # set CARGO_HTTP_MULTIPLEXING=false + retries (crates.io HTTP2 flakes on
+    # linux_aarch64 runners kill cargo-bundle-licenses otherwise).
     - cargo-bundle-licenses
     - cmake
     - ninja

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "2.14.0"
+  version: "2.15.0"
 
 package:
   name: eon
@@ -7,12 +7,10 @@ package:
 
 source:
   - url: https://github.com/TheochemUI/eOn/releases/download/v${{ version }}/eon-v${{ version }}.tar.xz
-    sha256: 3ac43fa2037a46bcc09e727647db504dd5ac55d4b7627f56d3a5ad6be38f765d
-    # fix_vesin_const.patch landed upstream for v2.14.0 and is no longer needed.
-    # fix_win_cuh2_potinit: v2.14.0 static aluminum+cuh2 LNK2005 on potinit_ (MSVC).
-    # Drop when retargeting to v2.15.0+ (dlopen Fortran pots on main).
-    patches:
-      - fix_win_cuh2_potinit.patch
+    # Recompute after tag push: curl -sL "$url" | sha256sum
+    # Placeholder from local git archive HEAD (release/v2.15.0-prep); replace with GH asset hash.
+    sha256: b873ece9340d51e926b0e2215ef9fd4438a4ecba3081159c7ed69e18f84ae345
+    # v2.15.0+ ships runtime-loadable Fortran pots (#342); fix_win_cuh2_potinit was v2.14.0-only.
   - url: https://github.com/OmniPotentRPC/rgpot/archive/refs/tags/v1.0.3.tar.gz
     sha256: b46d9d6ecb0d47c621d7ec6051c19025d3254b366d4c98232168f74b75c0f7da
     target_directory: subprojects/rgpot

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -9,6 +9,10 @@ source:
   - url: https://github.com/TheochemUI/eOn/releases/download/v${{ version }}/eon-v${{ version }}.tar.xz
     sha256: 3ac43fa2037a46bcc09e727647db504dd5ac55d4b7627f56d3a5ad6be38f765d
     # fix_vesin_const.patch landed upstream for v2.14.0 and is no longer needed.
+    # fix_win_cuh2_potinit: v2.14.0 static aluminum+cuh2 LNK2005 on potinit_ (MSVC).
+    # Drop when retargeting to v2.15.0+ (dlopen Fortran pots on main).
+    patches:
+      - fix_win_cuh2_potinit.patch
   - url: https://github.com/OmniPotentRPC/rgpot/archive/refs/tags/v1.0.3.tar.gz
     sha256: b46d9d6ecb0d47c621d7ec6051c19025d3254b366d4c98232168f74b75c0f7da
     target_directory: subprojects/rgpot

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -16,15 +16,15 @@ source:
       - fix_capnpc.patch
 
 build:
-  # Windows (issue #15): IN-TREE Fortran enabled via compiler('fortran') + build.bat
-  # -Dwith_fortran=true -Dwith_cuh2=true. Not a skip-Fortran line. Stack /STACK:16M in meson.
+  # Windows (issue #15): IN-TREE Fortran via compiler('fortran') + build.bat
+  # -Dwith_fortran=true -Dwith_cuh2=true. build.bat forces MSVC AR=lib (not llvm-ar from flang).
   number: 0
 requirements:
   build:
     - ${{ compiler('c') }}
     - ${{ stdlib('c') }}
     - ${{ compiler('cxx') }}
-    # win-64: m2w64 gfortran (no MSVC Fortran); links with MSVC C++ via static objects
+    # win-64: flang (conda-forge) or gfortran; C++/link stay MSVC; AR=lib in build.bat
     # (issue #15 in-tree pots — see build.bat + rgoswami.me/posts/windows-compat-sci-cpp/)
     - ${{ compiler('fortran') }}
     # readcon-core is a Rust meson subproject since eon v2.13; its meson.build

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -16,14 +16,17 @@ source:
       - fix_capnpc.patch
 
 build:
+  # Windows (issue #15): IN-TREE Fortran enabled via compiler('fortran') + build.bat
+  # -Dwith_fortran=true -Dwith_cuh2=true. Not a skip-Fortran line. Stack /STACK:16M in meson.
   number: 0
 requirements:
   build:
     - ${{ compiler('c') }}
     - ${{ stdlib('c') }}
     - ${{ compiler('cxx') }}
-    - if: not win
-      then: ${{ compiler('fortran') }}
+    # win-64: m2w64 gfortran (no MSVC Fortran); links with MSVC C++ via static objects
+    # (issue #15 in-tree pots — see build.bat + rgoswami.me/posts/windows-compat-sci-cpp/)
+    - ${{ compiler('fortran') }}
     # readcon-core is a Rust meson subproject since eon v2.13; its meson.build
     # demands rustc plus cbindgen to generate the C header that ConFileIO.cpp
     # consumes. Missing either one aborts meson setup before any C++
@@ -102,6 +105,8 @@ tests:
       script:
         - eonclient -h
         - eonclient --version
+        # Windows builds are static + no in-tree Fortran; binary must still run.
+        - python -c "import eon; import sys; print('eon ok', sys.platform)"
       requirements:
         run:
           - libtorch *cpu*


### PR DESCRIPTION
# conda-forge/eon-feedstock — eon 2.15.0

**Fork branch:** `HaoZeke/eon-feedstock` `release/v2.15.0` (based on #26 windows Fortran work)  
**Upstream target:** `conda-forge/eon-feedstock` `main`  
**Depends on:** TheochemUI/eOn `v2.15.0` tag + `release.yml` publishing `eon-v2.15.0.tar.xz`

## Summary

Ship **eon 2.15.0** on conda-forge. Carries forward win-64 **in-tree Fortran** from #26 / issue #15 (`build.bat`: `-Dwith_fortran=true -Dwith_cuh2=true`, MSVC `AR=lib`, flang_rt `LIBPATH`). Drops `fix_win_cuh2_potinit.patch` (v2.14.0 static-link LNK2005 only; 2.15.0 uses runtime-loadable Fortran pots #342).

## Recipe edits (`recipe/recipe.yaml`)

| Field | Value |
|-------|--------|
| `context.version` | `"2.15.0"` |
| `source[0].url` | `https://github.com/TheochemUI/eOn/releases/download/v2.15.0/eon-v2.15.0.tar.xz` |
| `source[0].sha256` | **recompute after asset exists** (provisional local archive: `b873ece9340d51e926b0e2215ef9fd4438a4ecba3081159c7ed69e18f84ae345`) |
| `build.number` | `0` |
| patches (eon tarball) | none (removed `fix_win_cuh2_potinit.patch`) |
| rgpot extra source | unchanged (`fix_capnpc.patch`) |

```bash
# After GH release asset is live:
curl -sL https://github.com/TheochemUI/eOn/releases/download/v2.15.0/eon-v2.15.0.tar.xz | sha256sum
# paste into recipe.yaml source[0].sha256
```

## Checklist

- [ ] TheochemUI/eOn `release/v2.15.0-prep` merged to `main` (or fast-forward)
- [ ] Tag `v2.15.0` pushed on main (`git push origin main --follow-tags`)
- [ ] `release.yml` green: gate → tarball → gh-release → PyPI `eon-akmc==2.15.0` (stable)
- [ ] Asset `eon-v2.15.0.tar.xz` on GitHub release
- [ ] Feedstock sha256 updated to match **published** asset (not local git-archive)
- [ ] Azure/GHA feedstock matrix green (esp. win_64 with Fortran on)
- [ ] `conda install -c conda-forge eon=2.15.0` smoke: `import eon`, `eonclient -h`

## Paste-ready PR title

`eon 2.15.0 (win in-tree Fortran #15; drop v2.14.0 potinit patch)`

## Paste-ready PR body

```markdown
## Summary

- Bump **eon** to **2.15.0** (GitHub release tarball).
- Keeps **win-64 in-tree Fortran** enablement from #26 / issue #15.
- Removes `fix_win_cuh2_potinit.patch` (only needed for v2.14.0 static aluminum+CuH2 LNK2005; 2.15.0 uses dlopen Fortran pots upstream).

## Checklist
- [x] context.version == 2.15.0
- [ ] sha256 matches published `eon-v2.15.0.tar.xz` (update if provisional hash differs)
- [x] build.number reset to 0
- [x] Windows Fortran path retained (build.bat / compiler('fortran'))
- [ ] CI green on all platforms incl. win_64
```

## Open PR (maintainer)

```bash
cd /path/to/eon-feedstock
git checkout release/v2.15.0
# fix sha256 once asset exists, amend/push
GITGUARD_BYPASS_GH=1 gh pr create --repo conda-forge/eon-feedstock \
  --head HaoZeke:release/v2.15.0 --base main \
  --title "eon 2.15.0 (win in-tree Fortran #15; drop v2.14.0 potinit patch)" \
  --body-file /tmp/grok-goal-56c21c26bf32/implementer/feedstock-pr-v2.15.0.md
```
